### PR TITLE
Event sub

### DIFF
--- a/lib/Cogs/cog_supervisor.ex
+++ b/lib/Cogs/cog_supervisor.ex
@@ -1,0 +1,22 @@
+defmodule Alchemy.Cogs.CogSupervisor do
+  @moduledoc false
+  # Acts as the supervisor for the command handler, event handler,
+  # and event registry
+  alias Alchemy.Cogs.{CommandHandler, EventHandler, EventRegistry}
+  use Supervisor
+
+
+  def start_link(command_options) do
+    Supervisor.start_link(__MODULE__, {:ops, command_options}, name: __MODULE__)
+  end
+
+  def init({:ops, command_options}) do
+    children = [
+      supervisor(EventRegistry, []),
+      worker(CommandHandler, [command_options]),
+      worker(EventHandler, [])
+    ]
+
+    supervise(children, strategy: :one_for_one)
+  end
+end

--- a/lib/Cogs/command_handler.ex
+++ b/lib/Cogs/command_handler.ex
@@ -83,16 +83,18 @@ defmodule Alchemy.Cogs.CommandHandler do
 
   defp dispatch(message, state) do
      prefix = state["prefix"]
-     destructure([_, command, rest],
-                 message.content
-                 |> String.split([prefix, " "], parts: 3)
-                 |> Enum.concat(["", ""]))
-     case state[command] do
-       {mod, arity, method} ->
-         run_command(mod, method, arity, &String.split(&1), message, rest)
-       {mod, arity, method, parser} ->
-         run_command(mod, method, arity, parser, message, rest)
-         _ -> nil
+     if String.starts_with?(message.content, prefix) do
+       destructure([_, command, rest],
+                   message.content
+                   |> String.split([prefix, " "], parts: 3)
+                   |> Enum.concat(["", ""]))
+       case state[command] do
+         {mod, arity, method} ->
+           run_command(mod, method, arity, &String.split(&1), message, rest)
+         {mod, arity, method, parser} ->
+           run_command(mod, method, arity, parser, message, rest)
+           _ -> nil
+       end
      end
   end
 

--- a/lib/Cogs/command_handler.ex
+++ b/lib/Cogs/command_handler.ex
@@ -5,27 +5,27 @@ defmodule Alchemy.Cogs.CommandHandler do
 
 
   def add_commands(module, commands) do
-    GenServer.cast(Commands, {:add_commands, module, commands})
+    GenServer.cast(__MODULE__, {:add_commands, module, commands})
   end
 
 
   def set_prefix(new) do
-    GenServer.cast(Commands, {:set_prefix, new})
+    GenServer.cast(__MODULE__, {:set_prefix, new})
   end
 
 
   def unload(module) do
-    GenServer.call(Commands, {:unload, module})
+    GenServer.call(__MODULE__, {:unload, module})
   end
 
 
   def disable(func) do
-    GenServer.call(Commands, {:disable, func})
+    GenServer.call(__MODULE__, {:disable, func})
   end
 
 
   def dispatch(message) do
-    GenServer.cast(Commands, {:dispatch, message})
+    GenServer.cast(__MODULE__, {:dispatch, message})
   end
 
   ### Server ###
@@ -33,7 +33,7 @@ defmodule Alchemy.Cogs.CommandHandler do
   def start_link(options) do
     # String keys to avoid conflict with functions
     GenServer.start_link(__MODULE__, %{"prefix" => "!", "options" => options},
-                         name: Commands)
+                         name: __MODULE__)
   end
 
 

--- a/lib/Cogs/event_handler.ex
+++ b/lib/Cogs/event_handler.ex
@@ -9,29 +9,29 @@ defmodule Alchemy.Cogs.EventHandler do
 
   # Starts up a task for handle registered for that event
   def notify(msg) do
-    GenServer.cast(Events, {:notify, msg})
+    GenServer.cast(__MODULE__, {:notify, msg})
   end
 
 
   def disable(module, function) do
-    GenServer.call(Events, {:disable, module, function})
+    GenServer.call(__MODULE__, {:disable, module, function})
   end
 
 
   def unload(module) do
-    GenServer.call(Events, {:unload, module})
+    GenServer.call(__MODULE__, {:unload, module})
   end
 
   # Used at the beginning of the application to add said handles
   def add_handler(handle) do
-    GenServer.cast(Events, {:add_handle, handle})
+    GenServer.cast(__MODULE__, {:add_handle, handle})
   end
 
 
   ### Server ###
 
   def start_link do
-    GenServer.start_link(__MODULE__, %{}, name: Events)
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
   end
 
 

--- a/lib/Cogs/event_handler.ex
+++ b/lib/Cogs/event_handler.ex
@@ -4,6 +4,7 @@ defmodule Alchemy.Cogs.EventHandler do
   # to call to handle those casts.
   # This server is intended to be unique.
   use GenServer
+  alias Alchemy.Cogs.EventRegistry
 
 
   # Starts up a task for handle registered for that event
@@ -65,6 +66,7 @@ defmodule Alchemy.Cogs.EventHandler do
     Enum.each(Map.get(state, type, []), fn {m, f} ->
       Task.start(fn -> apply(m, f, args) end)
     end)
+    EventRegistry.dispatch({type, args})
     {:noreply, state}
   end
 

--- a/lib/Cogs/event_registry.ex
+++ b/lib/Cogs/event_registry.ex
@@ -1,0 +1,22 @@
+defmodule Alchemy.Cogs.EventRegistry do
+  @moduledoc false # Serves as a registry for processes wanting
+  # to subscribe to events. The dispatch will then be used to allow
+  # for dynamic hooking into events.
+
+  def start_link do
+    Registry.start_link(:duplicate, __MODULE__, [])
+  end
+
+
+  def subscribe do
+    # the calling process will be sent in
+    Registry.register(__MODULE__, :subscribed, nil)
+  end
+
+
+  def dispatch(event) do
+    Registry.dispatch(__MODULE__, :subscribed, fn entries ->
+      Enum.each(entries, fn {pid, _} -> send(pid, {:discord_event, event}) end)
+    end)
+  end
+end

--- a/lib/client.ex
+++ b/lib/client.ex
@@ -27,7 +27,7 @@ defmodule Alchemy.Client do
   alias Alchemy.{Channel, Reaction.Emoji, Embed,
                  Guild, Message, User, VoiceRegion}
   alias Alchemy.Cache.Supervisor, as: CacheSupervisor
-  alias Alchemy.Cogs.{CommandHandler, EventHandler}
+  alias Alchemy.Cogs.{CommandHandler, EventHandler, EventRegistry}
   import Alchemy.Discord.RateManager, only: [send_req: 2]
   use Alchemy.Discord.Types
 
@@ -68,7 +68,8 @@ defmodule Alchemy.Client do
       worker(CommandHandler, [options]),
       worker(GatewayManager, [token, options]),
       supervisor(GatewayRates, []),
-      supervisor(CacheSupervisor, [])
+      supervisor(CacheSupervisor, []),
+      supervisor(EventRegistry, [])
     ]
     supervise(children, strategy: :one_for_one)
   end

--- a/lib/client.ex
+++ b/lib/client.ex
@@ -27,7 +27,7 @@ defmodule Alchemy.Client do
   alias Alchemy.{Channel, Reaction.Emoji, Embed,
                  Guild, Message, User, VoiceRegion}
   alias Alchemy.Cache.Supervisor, as: CacheSupervisor
-  alias Alchemy.Cogs.{CommandHandler, EventHandler, EventRegistry}
+  alias Alchemy.Cogs.CogSupervisor
   import Alchemy.Discord.RateManager, only: [send_req: 2]
   use Alchemy.Discord.Types
 
@@ -64,12 +64,10 @@ defmodule Alchemy.Client do
   def init({token, options}) do
     children = [
       worker(RateManager, [token]),
-      worker(EventHandler, []),
-      worker(CommandHandler, [options]),
       worker(GatewayManager, [token, options]),
       supervisor(GatewayRates, []),
       supervisor(CacheSupervisor, []),
-      supervisor(EventRegistry, [])
+      supervisor(CogSupervisor, [options])
     ]
     supervise(children, strategy: :one_for_one)
   end

--- a/lib/cogs.ex
+++ b/lib/cogs.ex
@@ -1,5 +1,6 @@
 defmodule Alchemy.Cogs do
   alias Alchemy.Cogs.EventRegistry
+  alias Alchemy.Events
   @moduledoc """
   This module provides quite a bit of sugar for registering commands.
 
@@ -305,19 +306,7 @@ defmodule Alchemy.Cogs do
   end
   defmacro wait_for(type, func) do
     # convert the special cases we set in the Events module
-    type = case type do
-      :DM_channel_create -> :dm_channel_create
-      :DM_channel_delete -> :dm_channel_delete
-      :guild_join -> :guild_create
-      :user_ban -> :guild_ban
-      :user_unban -> :guild_unban
-      :message_edit -> :message_update
-      :bulk_delete -> :message_delete_bulk
-      :typing -> :typing_start
-      :settings_update -> :user_settings_update
-      :voice_update -> :voice_state_update
-      x -> x
-    end
+    type = Events.convert_type(type)
     quote do
       EventRegistry.subscribe()
       receive do
@@ -366,19 +355,7 @@ defmodule Alchemy.Cogs do
     end
   end
   defmacro wait_for(type, condition, func) do
-    type = case type do
-      :DM_channel_create -> :dm_channel_create
-      :DM_channel_delete -> :dm_channel_delete
-      :guild_join -> :guild_create
-      :user_ban -> :guild_ban
-      :user_unban -> :guild_unban
-      :message_edit -> :message_update
-      :bulk_delete -> :message_delete_bulk
-      :typing -> :typing_start
-      :settings_update -> :user_settings_update
-      :voice_update -> :voice_state_update
-      x -> x
-    end
+    type = Events.convert_type(type)
     m = __MODULE__
     quote do
       EventRegistry.subscribe()

--- a/lib/cogs.ex
+++ b/lib/cogs.ex
@@ -1,4 +1,5 @@
 defmodule Alchemy.Cogs do
+  alias Alchemy.Cogs.EventRegistry
   @moduledoc """
   This module provides quite a bit of sugar for registering commands.
 
@@ -228,6 +229,164 @@ defmodule Alchemy.Cogs do
     end
   end
   @doc """
+  Allows you to register a custom message parser for a command.
+
+  The parser will be applied to part of the message not used for command matching.
+  ```elixir
+  prefix <> command <> " " <> rest
+  ```
+
+  ## Examples
+  ```elixir
+  Cogs.set_parser(:echo, &List.wrap/1)
+  Cogs.def echo(rest) do
+    Cogs.say(rest)
+  end
+  ```
+  """
+  @type parser :: (String.t -> Enum.t)
+  defmacro set_parser(name, parser) do
+    parser = Macro.to_string(parser)
+    quote do
+      @commands update_in(@commands, [Atom.to_string(unquote(name))], fn
+        nil ->
+          {__MODULE__, 0, unquote(name), unquote(parser)}
+        {mod, x, name} ->
+          {mod, x, name, unquote(parser)}
+        full ->
+          full
+      end)
+    end
+  end
+  @doc """
+  Halts the current command until an event is received.
+
+  The event type is an item corresponding to the events in `Alchemy.Events`,
+  i.e. `on_message_edit` -> `Cogs.wait_for(:message_edit, ...)`. The `fun`
+  is the function that gets called with the relevant event arguments; see
+  `Alchemy.Events` for more info on what events have what arguments.
+
+  The `:message` event is a bit special, as it will specifically wait for
+  a message not triggered by a bot, in that specific channel, unlike other events,
+  which trigger generically across the entire bot.
+  ## Examples
+  ```elixir
+  Cogs.def color do
+    Cogs.say "What's your favorite color?"
+    Cogs.wait_for :message, fn msg ->
+      Cogs.say "\#{msg.content} is my favorite color too!"
+    end
+  end
+  ```
+  ```elixir
+  Cogs.def typing do
+    Cogs.say "I'm waiting for someone to type.."
+    Cogs.wait_for :typing, fn _,_,_ ->
+      Cogs.say "Someone somewhere started typing..."
+    end
+  ```
+  """
+  # messages need special treatment, to ignore bots
+  defmacro wait_for(:message, func) do
+    quote do
+      EventRegistry.subscribe()
+      cCcChannelCCid = var!(message).channel_id
+      receive do
+        {:discord_event, {:message_create,
+         [%{author: %{bot: false}, channel_id: ^cCcChannelCCid}] = args}} ->
+          apply(unquote(func), args)
+      end
+    end
+  end
+  defmacro wait_for(type, func) do
+    # convert the special cases we set in the Events module
+    type = case type do
+      :DM_channel_create -> :dm_channel_create
+      :DM_channel_delete -> :dm_channel_delete
+      :guild_join -> :guild_create
+      :user_ban -> :guild_ban
+      :user_unban -> :guild_unban
+      :message_edit -> :message_update
+      :bulk_delete -> :message_delete_bulk
+      :typing -> :typing_start
+      :settings_update -> :user_settings_update
+      :voice_update -> :voice_state_update
+      x -> x
+    end
+    quote do
+      EventRegistry.subscribe()
+      receive do
+        {:discord_event, {unquote(type), args}} ->
+          apply(unquote(func), args)
+      end
+    end
+  end
+  @doc """
+  Waits for a specific event satisfying a condition.
+
+  Same as `wait_for/2`, except this takes an extra condition that needs to be
+  met for the waiting to handle to trigger.
+  ## Examples
+  ```elixir
+  Cogs.def foo do
+    Cogs.say "Send me foo"
+    Cogs.wait_for(:message, & &1.content == "foo", fn _msg ->
+      Cogs.say "Nice foo man!"
+    end)
+  """
+  defmacro wait_for(:message, condition, func) do
+    m = __MODULE__
+    quote do
+      EventRegistry.subscribe()
+      unquote(m).wait(:message, unquote(condition),
+                                unquote(func), var!(message).channel_id)
+    end
+  end
+  defmacro wait_for(type, condition, func) do
+    type = case type do
+      :DM_channel_create -> :dm_channel_create
+      :DM_channel_delete -> :dm_channel_delete
+      :guild_join -> :guild_create
+      :user_ban -> :guild_ban
+      :user_unban -> :guild_unban
+      :message_edit -> :message_update
+      :bulk_delete -> :message_delete_bulk
+      :typing -> :typing_start
+      :settings_update -> :user_settings_update
+      :voice_update -> :voice_state_update
+      x -> x
+    end
+    m = __MODULE__
+    quote do
+      EventRegistry.subscribe()
+      unquote(m).wait(unquote(type), unquote(condition), unquote(func))
+    end
+  end
+  # Loops until the correct command is received
+  @doc false
+  def wait(:message, condition, func, channel_id) do
+    receive do
+      {:discord_event, {:message_create,
+       [%{author: %{bot: false}, channel_id: ^channel_id}] = args}} ->
+        if apply(condition, args) do
+          apply(func, args)
+        else
+          wait(:message, condition, func, channel_id)
+        end
+    end
+  end
+  @doc false
+  def wait(type, condition, func) do
+    receive do
+      {:discord_event, {^type, args}} ->
+        if apply(condition, args) do
+          apply(func, args)
+        else
+          wait(type, condition, func)
+        end
+    end
+  end
+  @doc """
   Registers a new command, under the name of the function.
 
   This macro modifies the function definition, to accept an extra
@@ -286,36 +445,7 @@ defmodule Alchemy.Cogs do
     new_func = {:def, ctx, [{name, ctx, injected}, body]}
     {name, length(args), new_func}
   end
-  @doc """
-  Allows you to register a custom message parser for a command.
 
-  The parser will be applied to part of the message not used for command matching.
-  ```elixir
-  prefix <> command <> " " <> rest
-  ```
-
-  ## Examples
-  ```elixir
-  Cogs.set_parser(:echo, &List.wrap/1)
-  Cogs.def echo(rest) do
-    Cogs.say(rest)
-  end
-  ```
-  """
-  @type parser :: (String.t -> Enum.t)
-  defmacro set_parser(name, parser) do
-    parser = Macro.to_string(parser)
-    quote do
-      @commands update_in(@commands, [Atom.to_string(unquote(name))], fn
-        nil ->
-          {__MODULE__, 0, unquote(name), unquote(parser)}
-        {mod, x, name} ->
-          {mod, x, name, unquote(parser)}
-        full ->
-          full
-      end)
-    end
-  end
 
 
   @doc false

--- a/lib/events.ex
+++ b/lib/events.ex
@@ -439,4 +439,22 @@ defmodule Alchemy.Events do
     end
   end
 
+  @doc false
+  # This is useful in a few places, converts "aliases" made here, into the internal
+  # event
+  def convert_type(type) do
+    case type do
+      :DM_channel_create -> :dm_channel_create
+      :DM_channel_delete -> :dm_channel_delete
+      :guild_join -> :guild_create
+      :user_ban -> :guild_ban
+      :user_unban -> :guild_unban
+      :message_edit -> :message_update
+      :bulk_delete -> :message_delete_bulk
+      :typing -> :typing_start
+      :settings_update -> :user_settings_update
+      :voice_update -> :voice_state_update
+      x -> x
+    end
+  end
 end


### PR DESCRIPTION
Adds the ability to fully hook into the event pipeline, temporarily, or for as long as the process lives.

This is used in `Cogs.wait_for`, allowing for a nice way of waiting for events to happen in commands.