### PR TITLE
voice: default to a youtube search if URL is unqualified

### DIFF
--- a/lib/Voice/controller.ex
+++ b/lib/Voice/controller.ex
@@ -93,7 +93,7 @@ defmodule Alchemy.Voice.Controller do
   defp youtube_stream(url) do
     %Proc{out: youtube} =
       Porcelain.spawn(Application.fetch_env!(:alchemy, :youtube_dl_path),
-        ["-q", "-f", "bestaudio", "-o", "-", url], [out: :stream])
+        ["-q", "-f", "bestaudio", "-o", "-", "--default-search", "ytsearch", url], [out: :stream])
     opts = [in: youtube, out: :stream]
     %Proc{out: audio_stream} =
       Porcelain.spawn(Application.fetch_env!(:alchemy, :ffmpeg_path),


### PR DESCRIPTION
If the URL is unqualified, youtube-dl will search youtube and begin downloading the first search item.