### PR TITLE
Cogs.CommandHandler: add proper argument parser

### DIFF
--- a/lib/Cogs/command_handler.ex
+++ b/lib/Cogs/command_handler.ex
@@ -44,13 +44,6 @@ defmodule Alchemy.Cogs.CommandHandler do
     |> Enum.filter(&(&1 != nil))
   end
 
-  def split(args) do
-    args
-    |> String.split("\"")
-    |> Enum.map_every(2, &String.split/1)
-    |> List.flatten
-  end
-
   defp get_command(message, state) do
      prefix = state.prefix
      destructure([_, command, rest],
@@ -59,7 +52,7 @@ defmodule Alchemy.Cogs.CommandHandler do
                  |> Enum.concat(["", ""]))
      case state[command] do
        {mod, arity, method} ->
-         command_tuple(mod, method, arity, &split/1, message, rest)
+         command_tuple(mod, method, arity, &Alchemy.Cogs.CommandHandler.ArgParser.parse/1, message, rest)
        {mod, arity, method, parser} ->
          command_tuple(mod, method, arity, parser, message, rest)
        _ ->

--- a/lib/Cogs/command_handler/arg_parser.ex
+++ b/lib/Cogs/command_handler/arg_parser.ex
@@ -1,0 +1,71 @@
+defmodule Alchemy.Cogs.CommandHandler.ArgParser do
+  def parse(rest) do
+    Enum.reverse(parse([], rest))
+  end
+
+  defp parse(args, "") do
+    args
+  end
+
+  defp parse(args, rest) do
+    rest = String.trim_leading(rest)
+    {arg, rest} = next_arg(rest)
+    arg = String.replace(arg, ~s/\\"/, ~s/"/)
+    args = [arg | args]
+    parse(args, rest)
+  end
+
+  defp next_arg(rest) do
+    space_index = find_next_space(rest)
+    quote_index = find_next_quote(rest)
+    cond do
+      # If they are the same, they are both nil.
+      space_index == quote_index ->
+        {rest, ""}
+      quote_index == nil or space_index < quote_index ->
+        {arg, " " <> rest} = String.split_at(rest, space_index)
+        {arg, rest}
+      true ->
+        # No String.split with regex because it will delete the character behind the quote.
+        {arg, ~s/"/ <> rest} = String.split_at(rest, quote_index)
+        case find_next_quote(rest) do
+          -1 -> {arg <> rest, ""}
+          quote_index ->
+            {arg2, ~s/"/ <> rest} = String.split_at(rest, quote_index)
+            arg = arg <> arg2
+            case rest do
+              " " <> rest -> {arg, rest}
+              rest ->
+                {arg3, rest} = next_arg(rest)
+                {arg <> arg3, rest}
+            end
+        end
+    end
+  end
+
+  defp find_next(regex, rest) do
+    case Regex.run(regex, rest, return: :index) do
+      [{index, _length}] -> index
+      nil -> nil
+    end
+  end
+
+  defp find_next_space(rest) do
+    find_next(~r/ /, rest)
+  end
+
+  defp find_next_quote(~s/"/ <> _rest) do
+    0
+  end
+
+  defp find_next_quote(rest) do
+    # Matches all quotes not preceeded by a slash.
+    case find_next(~r/[^\\]"/, rest) do
+      nil -> nil
+      quote_index ->
+         # Index points to character before quote.
+         # So increment it.
+         quote_index + 1
+    end
+  end
+end

--- a/lib/cogs.ex
+++ b/lib/cogs.ex
@@ -514,7 +514,7 @@ defmodule Alchemy.Cogs do
           {m, a, f, e} ->
             apply(m, f, [message | rest |> e.() |> Enum.take(a)])
           {m, a, f} ->
-            apply(m, f, [message | rest |> Alchemy.Cogs.CommandHandler.split |> Enum.take(a)])
+            apply(m, f, [message | rest |> Alchemy.Cogs.CommandHandler.ArgParser.parse |> Enum.take(a)])
           _x ->
             nil
         end
@@ -552,7 +552,7 @@ defmodule Alchemy.Cogs do
   @doc """
   Returns a map from command name (string) to the command information.
 
-  Each command is either `{module, arity, function_name}`, or 
+  Each command is either `{module, arity, function_name}`, or
   `{module, arity, function_name, parser}`.
 
   This can be useful for providing some kind of help command, or telling

--- a/test/Cogs/ArgParser/parse_test.exs
+++ b/test/Cogs/ArgParser/parse_test.exs
@@ -1,0 +1,9 @@
+defmodule Alchemy.Cogs.ArgParser.ParseTest do
+  use ExUnit.Case, async: true
+  alias Alchemy.Cogs.CommandHandler.ArgParser
+
+  test "parsing with random quotes and whitespace" do
+    args = ArgParser.parse(~s/ ab"xy.  ye"om"izi\\" xe"zcse"lo ase"be  43  xd  1.2.3.4 "tons" more here ""/)
+    assert args == [~s/abxy.  yeomizi" xezcselo asebe/, "43", "xd", "1.2.3.4", "tons", "more", "here", ""]
+  end
+end


### PR DESCRIPTION
This parser does not assume that the first element is unquoted, handles
quoted arguments combined with non quoted characters and also supports
escaping quotes within a quoted argument.

I also included a small test. In the future, I can break the single test
into multiple tests to isolate the functionality tested but I don't think
its necessary now.