### PR TITLE
Fix argument error on image_data/1

### DIFF
--- a/lib/Discord/api.ex
+++ b/lib/Discord/api.ex
@@ -57,7 +57,10 @@ defmodule Alchemy.Discord.Api do
 
 
   def image_data(url) do
-    {:ok, HTTPoison.get(url).body |> Base.encode64}
+    case HTTPoison.get(url) do
+      {:ok, res} -> {:ok, Base.encode64(res.body)}
+      {:error, e} -> {:error, e.reason}
+    end
   end
 
   # Fetches an image, encodes it base64, and then formats it in discord's


### PR DESCRIPTION
```
iex(2)> Alchemy.Discord.Api.image_data "https://i.imgur.com/nnhQbpY.jpg"
** (ArgumentError) argument error
    :erlang.apply({:ok, %HTTPoison.Response{body: <<255, 216, 255, 219, 0, 67, 0, 3,2, 2, 5, 2, 2, 3, 5, 2, 5, 3, 3, 3, 3, 4, 13, 9, 4, 4, 4, 4, 8, 6, 6, 5, 13, 19, 17,21, 11, 19, 17, 19, 19, 21, 13, 31, 26, 21, 23, ...>>,
```