### PR TITLE
Add `Guild.icon_url/3`.

### DIFF
--- a/lib/Structs/Guild/guild.ex
+++ b/lib/Structs/Guild/guild.ex
@@ -284,6 +284,32 @@ defmodule Alchemy.Guild do
     |> Enum.find(& &1 in member.roles) 
   end
 
+  defmacrop is_valid_guild_icon_url(type, size) do
+    quote do
+      unquote(type) in ["jpg", "jpeg", "png", "webp"] and
+      unquote(size) in [128, 256, 512, 1024, 2048]
+    end
+  end
+  @doc """
+  Get the icon image URL for the given guild.
+  If the guild does not have any icon, returns `nil`.
+
+  ## Parameters
+  - `type`: The returned image format. Can be any of `jpg`, `jpeg`, `png`, or `webp`.
+  - `size`: The desired size of the returned image. Must be a power of two.
+  If the parameters do not match these conditions, an `ArgumentError` is raised.
+  """
+  @spec icon_url(__MODULE__.t, String.t, 16..2048) :: String.t
+  def icon_url(guild, type \\ "png", size \\ 256) when is_valid_guild_icon_url(type, size) do
+    case guild.icon do
+      nil -> nil
+      hash -> "https://cdn.discordapp.com/icons/#{guild.id}/#{hash}.#{type}?size=#{size}"
+    end
+  end
+  def icon_url(_guild, _type, _size) do
+    raise ArgumentError, message: "invalid icon URL type and / or size"
+  end
+
   @doc false
   def from_map(map) do
     map

--- a/test/Structs/Guild/guild_test.exs
+++ b/test/Structs/Guild/guild_test.exs
@@ -1,0 +1,49 @@
+defmodule AlchemyTest.Structs.Guild.GuildTest do
+  use ExUnit.Case, async: true
+  alias Alchemy.Guild
+
+  setup do
+    without_icon = %{
+      "id" => "42",
+      "name" => "test guild",
+      "icon" => nil,
+      "splash" => nil,
+      "owner_id" => 20,
+      "permissions" => 0,
+      "region" => "unit test land",
+      "afk_channel_id" => nil,
+      "afk_timeout" => 0,
+      "verification_level" => 0,
+      "default_message_notifications" => 0,
+      "roles" => [],
+      "emojis" => [],
+      "features" => [],
+      "mfa_level" => 0
+    }
+    with_icon = Map.put(without_icon, "icon", "ababababa")
+    %{
+      guild_without_icon: Guild.from_map(without_icon),
+      guild_with_icon: Guild.from_map(with_icon)
+    }
+  end
+
+  test "`icon_url` for guild without icon hash is `nil`", %{guild_without_icon: guild} do
+    assert Guild.icon_url(guild) == nil
+  end
+
+  test "icon type and size are configurable", %{guild_with_icon: guild} do
+    assert String.contains?(Guild.icon_url(guild, "jpeg"), ".jpeg")
+    assert String.ends_with?(Guild.icon_url(guild, "jpg", 1024), "1024")
+  end
+
+  test "`icon_url` for guild with icon hash is a string", %{guild_with_icon: guild} do
+    assert is_bitstring(Guild.icon_url(guild))
+  end
+
+  test "`icon_url` for invalid params raises `ArgumentError`", %{guild_with_icon: guild} do
+    assert_raise ArgumentError, fn -> Guild.icon_url(guild, 42) end
+    assert_raise ArgumentError, fn -> Guild.icon_url(guild, "json") end
+    assert_raise ArgumentError, fn -> Guild.icon_url(guild, 42, 0) end
+    assert_raise ArgumentError, fn -> Guild.icon_url(guild, "abc", 51) end
+  end
+end


### PR DESCRIPTION
this pr adds `Guild.icon_url/3` which can be used to generate a friendly icon URL for guilds, similar to `User.avatar_url`.