### PR TITLE
Fix permissions mapping.

### DIFF
--- a/lib/Structs/permissions.ex
+++ b/lib/Structs/permissions.ex
@@ -129,15 +129,9 @@ defmodule Alchemy.Permissions do
   """
   @spec to_list(Integer) :: [permission]
   def to_list(bitset) do
-    bitset
-    |> Integer.to_charlist(2)
-    |> Enum.reverse
-    |> Stream.zip(@perms)
-    |> Enum.reduce([], fn
-      # 49 represents 1, 48 represents 0. CharLists are weird...
-      {49, perm}, acc -> [perm | acc]
-      {48, _}, acc -> acc
-    end)
+    @perm_map
+    |> Enum.reduce([], fn {k, v}, acc when (v &&& bitset) != 0 -> [k | acc]
+                          _, acc -> acc end)
   end
   @doc """
   Checks for the presence of a permission in a permission bitset.


### PR DESCRIPTION
In the discord documentation, the values 0x00000100,0x00000200 and 0x00080000 do not have permissions associated with them. This led to the @perm_map module attribute not correctly mapping permissions to the correct value. This pull request adds a @nil_flags attribute containing those missing values and correctly maps the remaining permissions.

Permissions.to_list/1 had a similar issue, so I have changed the implementation to instead use the @perm_map to build the list of permissions.