### PR TITLE
Fix aliases

### DIFF
--- a/lib/Discord/Endpoints/channels.ex
+++ b/lib/Discord/Endpoints/channels.ex
@@ -2,7 +2,7 @@ defmodule Alchemy.Discord.Channels do
   @moduledoc false
   alias Poison.Parser
   alias Alchemy.Discord.Api
-  alias Alchemy.{Channel, Channel.Invite, DMChannel, Message, User, Reaction.Emoji}
+  alias Alchemy.{Channel, Channel.Invite, Channel.DMChannel, Message, User, Reaction.Emoji}
 
   @root "https://discordapp.com/api/v6/channels/"
 

--- a/lib/Discord/Endpoints/users.ex
+++ b/lib/Discord/Endpoints/users.ex
@@ -1,7 +1,7 @@
 defmodule Alchemy.Discord.Users do
   @moduledoc false
   alias Alchemy.Discord.Api
-  alias Alchemy.{DMChannel, User, UserGuild}
+  alias Alchemy.{Channel.DMChannel, User, UserGuild}
 
   @root "https://discordapp.com/api/v6/users/"
 

--- a/lib/Discord/events.ex
+++ b/lib/Discord/events.ex
@@ -2,7 +2,7 @@ defmodule Alchemy.Discord.Events do
   @moduledoc false # This module contains the protocols
   # for updating the cache based on the events received from discord.
   # This module is then used by EventStage.Cache
-  alias Alchemy.{Channel, DMChannel, Guild.Emoji, Guild,
+  alias Alchemy.{Channel, Channel.DMChannel, Guild.Emoji, Guild,
                  Message, User, VoiceState}
   alias Alchemy.Guild.{GuildMember, Presence, Role}
   alias Alchemy.Cache.Supervisor, as: Cache

--- a/lib/cache.ex
+++ b/lib/cache.ex
@@ -9,7 +9,7 @@ defmodule Alchemy.Cache do
   to get information from the context of commands.
   """
   alias Alchemy.Cache.{Guilds, Guilds.GuildSupervisor}
-  alias Alchemy.{DMChannel, Channel, Guild, User, VoiceState, Voice}
+  alias Alchemy.{Channel.DMChannel, Channel, Guild, User, VoiceState, Voice}
   alias Alchemy.Guild.{Emoji, GuildMember, Presence, Role}
   alias Alchemy.Discord.Gateway.RateLimiter, as: Gateway
   import Alchemy.Structs, only: [to_struct: 2]


### PR DESCRIPTION
Fixes aliases / namespaces for the DMChannel struct. 
Direct messages work again. Tested with the following function:
```elixir
Cogs.def hello do
  with {:ok, %Alchemy.Channel.DMChannel{id: chan_id}} = Client.create_DM(message.author.id) do
    Client.send_message(chan_id, "Hello there")
  end
end
```