### PR TITLE
Add on_role_update event handler

### DIFF
--- a/lib/Discord/events.ex
+++ b/lib/Discord/events.ex
@@ -97,6 +97,21 @@ defmodule Alchemy.Discord.Events do
     {:role_create, [to_struct(role, Role), id]}
   end
 
+  def handle("GUILD_ROLE_UPDATE", %{"guild_id" => id, "role" => new_role = %{"id" => role_id}}) do
+    old_role =
+      case Guilds.safe_call(id, {:section, "roles"}) do
+        {:ok, guild} ->
+          case guild[role_id] do
+            nil  -> nil
+            role -> to_struct(role, Role)
+          end
+        {:error, _reason} -> nil
+      end
+    Guilds.update_role(id, new_role)
+    new_role = to_struct(new_role, Role)
+    {:role_update, [old_role, new_role, id]}
+  end
+
   def handle("GUILD_ROLE_DELETE", %{"guild_id" => guild_id, "role_id" => id}) do
     Guilds.remove_role(guild_id, id)
     {:role_delete, [id, guild_id]}

--- a/lib/events.ex
+++ b/lib/events.ex
@@ -317,6 +317,19 @@ defmodule Alchemy.Events do
   end
 
   @doc """
+  Registers a handle triggering whenever a role gets updated in a guild.
+
+  `args` : `Alchemy.Guild.role, Alchemy.Guild.role, snowflake`
+
+  Receives the old role, the new role and the id of the guild that it belongs
+  to. The old role may be `nil` if it was not already cached when the event
+  was received.
+  """
+  defmacro on_role_update(func) do
+    handle(:role_update, func)
+  end
+
+  @doc """
   Registers a handle triggering whenever a role gets deleted from a guild.
 
   `args` : `snowflake, snowflake`


### PR DESCRIPTION
This does *not* work correctly at the moment. `old_role` is very often `nil`, and it appears to be random whether or not the role is already cached. If it is `nil` at the start, it will *always* be `nil`, even though I am updating the guilds cache. Here's the test I'm using:
```elixir
defmodule AlchemyTest do
  use Application
  use Alchemy.Cogs

  alias Alchemy.Client
  alias Alchemy.Events

  defmodule Events do
    use Alchemy.Events

    Alchemy.Events.on_role_update(:handler)
    def handler(old_role, new_role, guild_id) do
      IO.inspect old_role # nil like 70% of the time
      IO.inspect new_role
      IO.inspect guild_id
      IO.inspect "============="
    end
  end

  @spec start(any, any) :: {:ok, pid}
  def start(_type, _args) do
    run = Client.start(System.get_env("TOKEN"))

    use Events

    run
  end
end
```
Note: the above code also seems to receive an update for the `@everyone` role whenever any other role is updated, hopefully that's expected behaviour.