### PR TITLE
Remove :applications key

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Alchemy.Mixfile do
 
   def application do
     # Specify extra applications you'll use from Erlang/Elixir
-    [extra_applications: [:logger], applications: [:httpoison, :porcelain]]
+    [extra_applications: [:logger]]
   end
 
   defp deps do


### PR DESCRIPTION
As mentioned in #91, the application key, since it's  basically telling the release to only include the specified applications.  