### PR TITLE
Fix ratelimits & use millisecond accuracy

### DIFF
--- a/lib/Discord/api.ex
+++ b/lib/Discord/api.ex
@@ -85,7 +85,9 @@ defmodule Alchemy.Discord.Api do
   end
 
   def request(type, url, data, token) do
-    headers = [{"Content-Type", "application/json"} | auth_headers(token)]
+    headers = auth_headers(token)
+    headers = [{"Content-Type", "application/json"} | headers]
+    headers = [{"X-RateLimit-Precision", "millisecond"} | headers]
     apply(HTTPoison, type, [url, data, headers])
   end
 

--- a/lib/Discord/rate_limits.ex
+++ b/lib/Discord/rate_limits.ex
@@ -9,10 +9,10 @@ defmodule Alchemy.Discord.RateLimits do
   end
 
   # will only match if the ratelimits are present
-  defp parse_headers(%{"X-RateLimit-Remaining" => remaining} = headers) do
+  defp parse_headers(%{"x-ratelimit-remaining" => remaining} = headers) do
     {remaining, _} = Integer.parse(remaining)
-    {reset_time, _} = Integer.parse(headers["X-RateLimit-Reset"])
-    {limit, _} = Integer.parse(headers["X-RateLimit-Limit"])
+    {reset_time, _} = Float.parse(headers["x-ratelimit-reset"])
+    {limit, _} = Integer.parse(headers["x-ratelimit-limit"])
     %RateInfo{limit: limit, remaining: remaining, reset_time: reset_time}
   end
 

--- a/lib/Discord/rate_manager.ex
+++ b/lib/Discord/rate_manager.ex
@@ -85,15 +85,12 @@ defmodule Alchemy.Discord.RateManager do
   end
 
   def throttle(rates) do
-    now = DateTime.utc_now() |> DateTime.to_unix()
+    now = :os.system_time(:millisecond) / 1000
     wait_time = rates.reset_time - now
 
     cond do
       wait_time > 0 ->
-        {:wait, wait_time * 1000}
-
-      wait_time == 0 ->
-        {:wait, 1000}
+        {:wait, Kernel.ceil(wait_time * 1000)}
 
       # this means the reset_time has passed
       true ->


### PR DESCRIPTION
- Fix ratelimits never being updated from initial pessimistic bucket size due to difference in case of headers
- Add millisecond accuracy to reset time
- Remove erroneous `1000ms` timeout