### PR TITLE
Add channel caching for CREATE & UPDATE and fix private channels

### DIFF
--- a/lib/Cache/guilds.ex
+++ b/lib/Cache/guilds.ex
@@ -140,6 +140,20 @@ defmodule Alchemy.Cache.Guilds do
     call(guild_id, {:pop, "roles", role_id})
   end
 
+  def add_channel(guild_id, %{"id" => id} = channel) do
+    Channels.add_channels([channel], channel["guild_id"]) # assume has guild_id, otherwise we have no idea where it belongs
+    call(guild_id, {:put, "channels", id, channel})
+  end
+
+  def update_channel(guild_id, channel) do
+    add_channel(guild_id, channel)
+  end
+
+  def remove_channel(guild_id, channel_id) do
+    Channels.remove_channel(channel_id)
+    call(guild_id, {:pop, "channels", channel_id})
+  end
+
   def update_presence(presence) do
     guild_id = presence["guild_id"]
     pres_id = presence["user"]["id"]

--- a/lib/cache.ex
+++ b/lib/cache.ex
@@ -8,7 +8,7 @@ defmodule Alchemy.Cache do
   functions that will correctly balance the cache and the api, as well as use macros
   to get information from the context of commands.
   """
-  alias Alchemy.Cache.{Guilds, Guilds.GuildSupervisor}
+  alias Alchemy.Cache.{Guilds, Guilds.GuildSupervisor, Channels}
   alias Alchemy.{Channel.DMChannel, Channel, Guild, User, VoiceState, Voice}
   alias Alchemy.Guild.{Emoji, GuildMember, Presence, Role}
   alias Alchemy.Discord.Gateway.RateLimiter, as: Gateway
@@ -26,10 +26,7 @@ defmodule Alchemy.Cache do
   """
   @spec guild_id(snowflake) :: {:ok, snowflake} | {:error, String.t()}
   def guild_id(channel_id) do
-    case :ets.lookup(:channels, channel_id) do
-      [{_, id}] -> {:ok, id}
-      [] -> {:error, "Failed to find a channel entry for #{channel_id}."}
-    end
+    Channels.lookup(channel_id)
   end
 
   @doc """


### PR DESCRIPTION
- Guild cache wasn't updated in response to channel changes. This has been fixed.
- Private channels should now be correctly handled (beforehand they used a property that must have existed in an earlier API version)