### PR TITLE
discordapp.com -> discord.com

### DIFF
--- a/lib/Discord/Endpoints/channels.ex
+++ b/lib/Discord/Endpoints/channels.ex
@@ -4,7 +4,7 @@ defmodule Alchemy.Discord.Channels do
   alias Alchemy.Discord.Api
   alias Alchemy.{Channel, Channel.Invite, Channel.DMChannel, Message, User, Reaction.Emoji}
 
-  @root "https://discordapp.com/api/v6/channels/"
+  @root "https://discord.com/api/v6/channels/"
 
   def parse_channel(json) do
     parsed = Parser.parse!(json, %{})

--- a/lib/Discord/Endpoints/guilds.ex
+++ b/lib/Discord/Endpoints/guilds.ex
@@ -5,7 +5,7 @@ defmodule Alchemy.Discord.Guilds do
   alias Alchemy.Guild.{GuildMember, Integration, Role}
   alias Alchemy.AuditLog
 
-  @root "https://discordapp.com/api/v6/guilds/"
+  @root "https://discord.com/api/v6/guilds/"
 
   # returns information for a current guild; cache should be preferred over this
   def get_guild(token, guild_id) do
@@ -170,7 +170,7 @@ defmodule Alchemy.Discord.Guilds do
   end
 
   def get_all_regions(token) do
-    "https://discordapp.com/api/v6/voice/regions"
+    "https://discord.com/api/v6/voice/regions"
     |> Api.get(token, [%VoiceRegion{}])
   end
 

--- a/lib/Discord/Endpoints/invites.ex
+++ b/lib/Discord/Endpoints/invites.ex
@@ -2,7 +2,7 @@ defmodule Alchemy.Discord.Invites do
   @moduledoc false
   alias Alchemy.Discord.Api
   alias Alchemy.Channel.Invite
-  @root "https://discordapp.com/api/v6/invites/"
+  @root "https://discord.com/api/v6/invites/"
 
   def get_invite(token, code) do
     (@root <> code)

--- a/lib/Discord/Endpoints/users.ex
+++ b/lib/Discord/Endpoints/users.ex
@@ -3,7 +3,7 @@ defmodule Alchemy.Discord.Users do
   alias Alchemy.Discord.Api
   alias Alchemy.{Channel.DMChannel, User, UserGuild}
 
-  @root "https://discordapp.com/api/v6/users/"
+  @root "https://discord.com/api/v6/users/"
 
   # Returns a User struct, passing "@me" gets info for the current Client instead
   # Token is the first arg so that it can be prepended generically

--- a/lib/Discord/Endpoints/webhooks.ex
+++ b/lib/Discord/Endpoints/webhooks.ex
@@ -3,7 +3,7 @@ defmodule Alchemy.Discord.Webhooks do
   alias Alchemy.Discord.Api
   alias Alchemy.Webhook
 
-  @root "https://discordapp.com/api/v6/"
+  @root "https://discord.com/api/v6/"
 
   def create_webhook(token, channel_id, name, options) do
     options =

--- a/lib/Discord/Gateway/manager.ex
+++ b/lib/Discord/Gateway/manager.ex
@@ -24,14 +24,14 @@ defmodule Alchemy.Discord.Gateway.Manager do
 
   defp get_url(_token, selfbot: _) do
     json =
-      Api.get!("https://discordapp.com/api/v6/gateway").body
+      Api.get!("https://discord.com/api/v6/gateway").body
       |> (fn x -> Poison.Parser.parse!(x, %{}) end).()
 
     {json["url"] <> "?v=6&encoding=json", 1}
   end
 
   defp get_url(token, []) do
-    url = "https://discordapp.com/api/v6/gateway/bot"
+    url = "https://discord.com/api/v6/gateway/bot"
 
     json =
       Api.get!(url, token).body

--- a/lib/Structs/Messages/Embed/embed.ex
+++ b/lib/Structs/Messages/Embed/embed.ex
@@ -347,7 +347,7 @@ defmodule Alchemy.Embed do
   Cogs.def embed do
     %Embed{}
     |> author(name: "John",
-              url: "https://discordapp.com/developers"
+              url: "https://discord.com/developers"
               icon_url: "http://i.imgur.com/3nuwWCB.jpg")
     |> Embed.send
   end

--- a/lib/Structs/audit_log.ex
+++ b/lib/Structs/audit_log.ex
@@ -189,7 +189,7 @@ defmodule Alchemy.AuditLog do
     The type of change that occurred. This also dictates the type of
     `new_value` and `old_value`
 
-  [more information on this relation](https://discordapp.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-key)
+  [more information on this relation](https://discord.com/developers/docs/resources/audit-log#audit-log-change-object-audit-log-change-key)
   """
   @type change :: %__MODULE__.Change{
           new_value: any,


### PR DESCRIPTION
On November 7, 2020 Discord will be dropping support for the discordapp.com domain in favor of discord.com.

This PR replaces all occurrences of discordapp.com with discord.com. 
(except for cdn.discordapp.com which remains for the forseeable future)

> Last month, we excitedly announced our official move to discord.com. It was a long time in the making, and the work isn't done yet! For now, our API will continue to handle requests made to discordapp.com. On November 7, 2020 we will be dropping support for the discordapp.com domain in favor of discord.com. Please ensure that your libraries, bots, and applications are updated accordingly.
> 
> Due to technical constraints, our CDN domain will not be migrated and will remain cdn.discordapp.com for the foreseeable future.