### PR TITLE
Fix `Alchemy.Client.create_channel/3` crash for 201 status code response

### DIFF
--- a/lib/Discord/rate_limits.ex
+++ b/lib/Discord/rate_limits.ex
@@ -25,7 +25,7 @@ defmodule Alchemy.Discord.RateLimits do
     nil
   end
 
-  def rate_info(%{status_code: 200, headers: h}) do
+  def rate_info(%{status_code: status_code, headers: h}) when status_code in [200, 201] do
     h |> Enum.into(%{}) |> parse_headers
   end
 


### PR DESCRIPTION
Fixes #103 

Changes:
- added a guardian in `Discord.RateLimits.rate_info/3` to match with Discord's 201 status code response when creating a channel