### PR TITLE
Handle channel type 5 & 6 (news/store)

### DIFF
--- a/lib/Structs/Channels/channel.ex
+++ b/lib/Structs/Channels/channel.ex
@@ -9,7 +9,9 @@ defmodule Alchemy.Channel do
     ChannelCategory,
     VoiceChannel,
     DMChannel,
-    GroupDMChannel
+    GroupDMChannel,
+    NewsChannel,
+    StoreChannel
   }
 
   alias Alchemy.User
@@ -324,6 +326,8 @@ defmodule Alchemy.Channel do
       2 -> VoiceChannel.from_map(map)
       3 -> GroupDMChannel.from_map(map)
       4 -> ChannelCategory.from_map(map)
+      5 -> NewsChannel.from_map(map)
+      6 -> StoreChannel.from_map(map)
     end
   end
 end

--- a/lib/Structs/Channels/news_channel.ex
+++ b/lib/Structs/Channels/news_channel.ex
@@ -1,0 +1,23 @@
+defmodule Alchemy.Channel.NewsChannel do
+  @moduledoc false
+  alias Alchemy.OverWrite
+  import Alchemy.Structs
+
+  defstruct [
+    :id,
+    :guild_id,
+    :position,
+    :permission_overwrites,
+    :name,
+    :topic,
+    :nsfw,
+    :last_message_id,
+    :parent_id
+  ]
+
+  def from_map(map) do
+    map
+    |> field_map("permission_overwrites", &map_struct(&1, OverWrite))
+    |> to_struct(__MODULE__)
+  end
+end

--- a/lib/Structs/Channels/store_channel.ex
+++ b/lib/Structs/Channels/store_channel.ex
@@ -1,0 +1,24 @@
+defmodule Alchemy.Channel.StoreChannel do
+  @moduledoc false
+  alias Alchemy.OverWrite
+  import Alchemy.Structs
+
+  # Note: should never encounter a store channel, as they're not something
+  # bots can send/read to.  It's "the store."
+  
+  defstruct [
+    :id,
+    :guild_id,
+    :position,
+    :permission_overwrites,
+    :name,
+    :last_message_id,
+    :parent_id
+  ]
+
+  def from_map(map) do
+    map
+    |> field_map("permission_overwrites", &map_struct(&1, OverWrite))
+    |> to_struct(__MODULE__)
+  end
+end


### PR DESCRIPTION
I ran into a crash when my bot was added to a discord server that apparently had a news channel.  This adds knowledge of the channel structures for 5 (news) and 6 (store) based on https://discord.com/developers/docs/resources/channel#channel-object-channel-types .
If there's additional implementation needed to read or write to a news channel, it's not handled by this patch.
