### PR TITLE
Fix `Alchemy.Reactions.Emoji.resolve/1` crashing all reaciton management related functions

### DIFF
--- a/lib/Structs/Channels/channel.ex
+++ b/lib/Structs/Channels/channel.ex
@@ -9,7 +9,9 @@ defmodule Alchemy.Channel do
     ChannelCategory,
     VoiceChannel,
     DMChannel,
-    GroupDMChannel
+    GroupDMChannel,
+    NewsChannel,
+    StoreChannel
   }
 
   alias Alchemy.User
@@ -159,7 +161,7 @@ defmodule Alchemy.Channel do
 
     Whether or not the channel is considered nsfw
   - `last_message_id`
-    
+
     The id of the last message sent in the channel, if any
   - `parent_id`
 
@@ -222,7 +224,7 @@ defmodule Alchemy.Channel do
 
     The id of the guild this channel belongs to
   - `position`
-    
+
     The sorting position of this channel in the guild
   - `permission_overwrites`
 
@@ -324,6 +326,8 @@ defmodule Alchemy.Channel do
       2 -> VoiceChannel.from_map(map)
       3 -> GroupDMChannel.from_map(map)
       4 -> ChannelCategory.from_map(map)
+      5 -> NewsChannel.from_map(map)
+      6 -> StoreChannel.from_map(map)
     end
   end
 end

--- a/lib/Structs/Channels/channel.ex
+++ b/lib/Structs/Channels/channel.ex
@@ -15,7 +15,6 @@ defmodule Alchemy.Channel do
   }
 
   alias Alchemy.User
-  import Alchemy.Structs
 
   @moduledoc """
   This module contains useful functions for operating on `Channels`.

--- a/lib/Structs/Channels/news_channel.ex
+++ b/lib/Structs/Channels/news_channel.ex
@@ -1,0 +1,23 @@
+defmodule Alchemy.Channel.NewsChannel do
+  @moduledoc false
+  alias Alchemy.OverWrite
+  import Alchemy.Structs
+
+  defstruct [
+    :id,
+    :guild_id,
+    :position,
+    :permission_overwrites,
+    :name,
+    :topic,
+    :nsfw,
+    :last_message_id,
+    :parent_id
+  ]
+
+  def from_map(map) do
+    map
+    |> field_map("permission_overwrites", &map_struct(&1, OverWrite))
+    |> to_struct(__MODULE__)
+  end
+end

--- a/lib/Structs/Channels/store_channel.ex
+++ b/lib/Structs/Channels/store_channel.ex
@@ -1,0 +1,24 @@
+defmodule Alchemy.Channel.StoreChannel do
+  @moduledoc false
+  alias Alchemy.OverWrite
+  import Alchemy.Structs
+
+  # Note: should never encounter a store channel, as they're not something
+  # bots can send/read to.  It's "the store."
+
+  defstruct [
+    :id,
+    :guild_id,
+    :position,
+    :permission_overwrites,
+    :name,
+    :last_message_id,
+    :parent_id
+  ]
+
+  def from_map(map) do
+    map
+    |> field_map("permission_overwrites", &map_struct(&1, OverWrite))
+    |> to_struct(__MODULE__)
+  end
+end

--- a/lib/Structs/Messages/Reactions/emoji.ex
+++ b/lib/Structs/Messages/Reactions/emoji.ex
@@ -5,11 +5,34 @@ defmodule Alchemy.Reaction.Emoji do
   defstruct [:id,
              :name]
 
+  @type t :: %__MODULE__{id: String.t(), name: String.t()}
 
-  @doc false
+
+  @doc """
+    Returns the %Emoji{} struct,
+    resolving its values according with the data type of the parameter `emoji`.
+
+    ## Example
+    ```shell
+    iex(1)> Alchemy.Reaction.Emoji.resolve(%Emoji{id: nil, name: "✅"})
+    %Emoji{id: nil, name: "✅"}
+
+    iex(2)> Alchemy.Reaction.Emoji.resolve(%{id: nil, name: "✅"})
+    %Emoji{id: nil, name: "✅"}
+
+    iex(3)> Alchemy.Reaction.Emoji.resolve(%{"id" => nil, "name" => "✅"})
+    %Emoji{id: nil, name: "✅"}
+
+    iex(4)> Alchemy.Reaction.Emoji.resolve("✅")
+    %Emoji{id: nil, name: "✅"}
+    ```
+  """
+  @spec resolve(emoji :: any()) :: Emoji.t()
   def resolve(emoji) do
     case emoji do
       %__MODULE__{} = em -> em
+      %{"id" => id, "name" => name} -> %__MODULE__{id: id, name: name}
+      %{id: id, name: name} -> %__MODULE__{id: id, name: name}
       unicode -> %__MODULE__{name: unicode}
     end
   end

--- a/lib/cogs.ex
+++ b/lib/cogs.ex
@@ -3,7 +3,6 @@ defmodule Alchemy.Cogs do
   alias Alchemy.Cogs.CommandHandler
   alias Alchemy.Cogs.EventRegistry
   alias Alchemy.Events
-  alias Alchemy.Guild
   require Logger
 
   @moduledoc """
@@ -604,7 +603,7 @@ defmodule Alchemy.Cogs do
   @doc """
   Returns a map from command name (string) to the command information.
 
-  Each command is either `{module, arity, function_name}`, or 
+  Each command is either `{module, arity, function_name}`, or
   `{module, arity, function_name, parser}`.
 
   This can be useful for providing some kind of help command, or telling
@@ -643,7 +642,7 @@ defmodule Alchemy.Cogs do
   Returns the permission bitset of the current member in the channel the command
   was called from.
 
-  If you just want the base permissions of the member in the guild, 
+  If you just want the base permissions of the member in the guild,
   see `guild_permissions`.
   Returns `{:ok, perms}`, or `{:error, why}`. Fails if not called from
   a guild, or the guild or the member couldn't be fetched from the cache.

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Alchemy.Mixfile do
   def project do
     [
       app: :alchemy,
-      version: "0.6.7",
+      version: "0.6.8",
       elixir: "~> 1.8",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Alchemy.Mixfile do
   def project do
     [
       app: :alchemy,
-      version: "0.6.6",
+      version: "0.6.7",
       elixir: "~> 1.8",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Fixes #109 

# Description
The `Alchemy.Reactions.Emoji.resolve/1` considers only two scenarios:
- when the emoji is already a struct
- when the emoji is anything

In this second scenario, this function is building the struct in a wrong way when the paramater is a map. This causes Elixir to crash when it tries to convert the emoji's name to string (this is required to build the url, so Uri can encode it [here](https://github.com/cronokirby/alchemy/blob/master/lib/Discord/Endpoints/channels.ex#L96) for example). With this fix, this function will do a proper job when the parameter is a map.