### PR TITLE
FIX: Cache crashes if guild not present when handling event

### DIFF
--- a/lib/Cache/channels.ex
+++ b/lib/Cache/channels.ex
@@ -47,7 +47,7 @@ defmodule Alchemy.Cache.Channels do
   def handle_call({:lookup, channel_id}, _, table) do
     case :ets.lookup(table, channel_id) do
       [{_, guild_id}] -> {:reply, {:ok, guild_id}, table}
-      []              -> {:reply, {:error, "Failed to find a channel entry for #{channel_id}."}, table}
+      [] -> {:reply, {:error, "Failed to find a channel entry for #{channel_id}."}, table}
     end
   end
 end

--- a/lib/Cache/guilds.ex
+++ b/lib/Cache/guilds.ex
@@ -39,9 +39,8 @@ defmodule Alchemy.Cache.Guilds do
     end
   end
 
-  def call(id, msg, retries \\ 10) do
-    {:via, registry, {key, id}} = via_guilds(id)
-    GenServer.call({:via, registry, {key, id}}, msg)
+  def call(id, msg) do
+    GenServer.call(via_guilds(id), msg)
   end
 
   def start_link(%{"id" => id} = guild) do

--- a/lib/Cache/guilds.ex
+++ b/lib/Cache/guilds.ex
@@ -3,6 +3,7 @@ defmodule Alchemy.Cache.Guilds do
   @moduledoc false
   # by the supervisor in the submodule below
   use GenServer
+  require Logger
   alias Alchemy.Cache.Guilds.GuildSupervisor
   alias Alchemy.Cache.Channels
   alias Alchemy.Guild
@@ -39,8 +40,44 @@ defmodule Alchemy.Cache.Guilds do
     end
   end
 
-  def call(id, msg) do
-    GenServer.call(via_guilds(id), msg)
+  def call(id, msg, retries \\ 10) do
+    {:via, registry, {key, id}} = via_guilds(id)
+
+    # This is to handle possible calls for a guild
+    # which has not been registered yet.
+    #
+    # This can happen when a bot joins a guild
+    # and at the same time any member gets updated - new username, new role assigned etc.
+    #
+    # We will receive the signals GUILD_MEMBER_UPDATE & GUILD_CREATE simultaneously.
+    #
+    # If the GUILD_MEMBER_UPDATE signal gets processed before the GUILD_CREATE
+    # the Cache will crash as no genserver with the given guild id exists in the 
+    # Registry yet. 
+    #
+    # To prevent that we check if the guild exists
+    # and if not we will check again after 500ms.
+    # We do this 10 times, which equals 5s. 
+    # If the guild has not been found afterwards, the msg will be discarded.
+    case registry.lookup(key, id) do
+
+      [] ->
+        if retries > 0 do
+          Task.start(fn ->
+            :timer.sleep(500)
+            call(id, msg, retries - 1)
+          end)
+        else
+          Logger.error(
+            "Guild with id #{id} is not present in registry. Max retries reached, not delivering message: #{
+              inspect(msg)
+            }"
+          )
+        end
+
+      _ ->
+        GenServer.call({:via, registry, {key, id}}, msg)
+    end
   end
 
   def start_link(%{"id" => id} = guild) do
@@ -141,7 +178,8 @@ defmodule Alchemy.Cache.Guilds do
   end
 
   def add_channel(guild_id, %{"id" => id} = channel) do
-    Channels.add_channels([channel], channel["guild_id"]) # assume has guild_id, otherwise we have no idea where it belongs
+    # assume has guild_id, otherwise we have no idea where it belongs
+    Channels.add_channels([channel], channel["guild_id"])
     call(guild_id, {:put, "channels", id, channel})
   end
 

--- a/lib/EventStage/cacher.ex
+++ b/lib/EventStage/cacher.ex
@@ -35,7 +35,6 @@ defmodule Alchemy.EventStage.Cacher do
   end
 
   defp handle_event(type, %{"guild_id" => guild_id} = payload) when is_binary(guild_id) do
-    
     # This is to handle possible calls for a guild
     # which has not been registered yet.
     #
@@ -47,10 +46,15 @@ defmodule Alchemy.EventStage.Cacher do
     # If the GUILD_MEMBER_UPDATE signal gets processed before the GUILD_CREATE
     # the Cache will crash as no genserver with the given guild id exists in the 
     # Registry yet. 
-    if Registry.lookup(:guilds, guild_id) != [] do  
-        Events.handle(type, payload)
+    if Registry.lookup(:guilds, guild_id) != [] do
+      Events.handle(type, payload)
     else
-        Logger.debug("Not handling #{inspect(type)} for #{guild_id} as the guild has not been started yet. Payload was #{inspect(payload)}")
+      Logger.debug(
+        "Not handling #{inspect(type)} for #{guild_id} as the guild has not been started yet. Payload was #{
+          inspect(payload)
+        }"
+      )
+
       {:unkown, []}
     end
   end
@@ -58,5 +62,4 @@ defmodule Alchemy.EventStage.Cacher do
   defp handle_event(type, payload) do
     Events.handle(type, payload)
   end
-
 end


### PR DESCRIPTION
If the bot is running and someones add the bot to another guild the cache can crash and become unresponsive if at the same time another event occurs in the guild.

For instance. if the bot _FooBar_ joins a guild where another bot assigns all new members a role, then discord would send the signals `GUILD_MEMBER_UPDATE` & `GUILD_CREATE` simultaneously. It can happen that the `GUILD_MEMBER_UPDATE` is being processed before the `GUILD_CREATE` signal. 

But as the guild may not exist yet, this can crash here: https://github.com/cronokirby/alchemy/blob/edb04294b10dfe16e2b40dcc31a4937f9382c0b6/lib/Cache/guilds.ex#L43

To prevent that, we can just handle all events that come in and check if a GenServer with the associated guild_id is already running. 

-----
Unfortunately, as the scenario sounds quite uncommon it happens quite often as a lot of larger guilds have bots that assign roles when a new member joins or have a welcome message posted in a channel. 
