### PR TITLE
FIX: Gateway manager infinity loop (crucial) 

### DIFF
--- a/lib/Discord/Gateway/gateway.ex
+++ b/lib/Discord/Gateway/gateway.ex
@@ -15,11 +15,18 @@ defmodule Alchemy.Discord.Gateway do
   def start_link(token, shard) do
     :crypto.start()
     :ssl.start()
+
     # request_url will return a protocol to execute
-    url = Manager.request_url().()
+    # which either returns the url or another protocol
+    # to execute.
+    url = Manager.request_url().() |> get_url
     Logger.info("Shard #{inspect(shard)} connecting to the gateway")
+
     :websocket_client.start_link(url, __MODULE__, %State{token: token, shard: shard})
   end
+
+  def get_url(s) when is_binary(s), do: s
+  def get_url(f), do: get_url(f.())
 
   def init(state) do
     {:once, state}


### PR DESCRIPTION
This fixes a very crucial error which can causes the bot to become
unresponsive.

Start multiple instances of the bot with the same token.
Some will get the error message that the session id is invalid: OP 9

As a result the Gateway will be terminated and restarted.
In some cases this will work as expected but in others it ends in an
endless loop:

The gateway will call `Manager.request_url().()` which previously
updated the url_reset timer by 5 seconds even if the process who
requested the url has not been successful. The returned function
sleeps for 1sec before requesting again. But as it only slept 1sec
the url_reset is still higher than now(). But now we increase the
url_reset again by 5sec. This reminds me of Achilles and the tortoise :)
It will never be faster and pass the increasing 5sec of the url_reset.

First fix: We should only increase the url_reset by 5sec if the process
successfully acquired the url.

Second fix: `Manager.request_url().()` will either return a string
or a protocol again. So we have to check for this also as we may pass
a function to :websocket_client.start_link which will result in an
error and the process terminates and restarts. We can avoid that.