### PR TITLE
Bug Fix: Bot crashes as new channel type is not being support

### DIFF
--- a/lib/Structs/Channels/StageVoiceChannel.ex
+++ b/lib/Structs/Channels/StageVoiceChannel.ex
@@ -1,0 +1,26 @@
+defmodule Alchemy.Channel.StageVoiceChannel do
+  @moduledoc false
+  alias Alchemy.OverWrite
+  import Alchemy.Structs
+
+  defstruct [
+    :id,
+    :guild_id,
+    :position,
+    :permission_overwrites,
+    :name,
+    :nsfw,
+    :bitrate,
+    :user_limit,
+    :parent_id,
+    :rtc_region,
+    :topic,
+    :video_quality_mode
+  ]
+
+  def from_map(map) do
+    map
+    |> field_map("permission_overwrites", &map_struct(&1, OverWrite))
+    |> to_struct(__MODULE__)
+  end
+end

--- a/lib/Structs/Channels/channel.ex
+++ b/lib/Structs/Channels/channel.ex
@@ -11,7 +11,8 @@ defmodule Alchemy.Channel do
     DMChannel,
     GroupDMChannel,
     NewsChannel,
-    StoreChannel
+    StoreChannel,
+    StageVoiceChannel
   }
 
   alias Alchemy.User
@@ -328,6 +329,8 @@ defmodule Alchemy.Channel do
       4 -> ChannelCategory.from_map(map)
       5 -> NewsChannel.from_map(map)
       6 -> StoreChannel.from_map(map)
+      13 -> StageVoiceChannel.from_map(map)
+      _ -> nil
     end
   end
 end

--- a/lib/Structs/Channels/channel.ex
+++ b/lib/Structs/Channels/channel.ex
@@ -1,4 +1,6 @@
 defmodule Alchemy.Channel do
+  require Logger
+
   alias Alchemy.OverWrite
 
   alias Alchemy.Channel.{
@@ -322,15 +324,33 @@ defmodule Alchemy.Channel do
   @doc false
   def from_map(map) do
     case map["type"] do
-      0 -> TextChannel.from_map(map)
-      1 -> DMChannel.from_map(map)
-      2 -> VoiceChannel.from_map(map)
-      3 -> GroupDMChannel.from_map(map)
-      4 -> ChannelCategory.from_map(map)
-      5 -> NewsChannel.from_map(map)
-      6 -> StoreChannel.from_map(map)
-      13 -> StageVoiceChannel.from_map(map)
-      _ -> nil
+      0 ->
+        TextChannel.from_map(map)
+
+      1 ->
+        DMChannel.from_map(map)
+
+      2 ->
+        VoiceChannel.from_map(map)
+
+      3 ->
+        GroupDMChannel.from_map(map)
+
+      4 ->
+        ChannelCategory.from_map(map)
+
+      5 ->
+        NewsChannel.from_map(map)
+
+      6 ->
+        StoreChannel.from_map(map)
+
+      13 ->
+        StageVoiceChannel.from_map(map)
+
+      _ ->
+        Logger.error("Unkown channel type: #{inspect(map)}")
+        nil
     end
   end
 end


### PR DESCRIPTION
@cronokirby Currently the bot will crash if it is part of a guild where the guild has the new channel type StageVoiceChannel. 

I have added support for that. Furthermore, if a channel type is unknown it will return nil and log an error and won't crash anymore.