### PR TITLE
BUG: Event stage crashes due to missing embed field

### DIFF
--- a/lib/Structs/Messages/message.ex
+++ b/lib/Structs/Messages/message.ex
@@ -118,7 +118,7 @@ defmodule Alchemy.Message do
     |> field?("author", User)
     |> field_map?("mentions", &map_struct(&1, User))
     |> field_map?("attachments", &map_struct(&1, Attachment))
-    |> field_map("embeds", &Enum.map(&1, fn x -> Embed.from_map(x) end))
+    |> field_map?("embeds", &Enum.map(&1, fn x -> Embed.from_map(x) end))
     |> field_map?("reactions", &map_struct(&1, Reaction))
     |> to_struct(__MODULE__)
   end


### PR DESCRIPTION
There are new events that are missing the embed key. Haven't had the time to check which kind of events but I am on it. In the meantime, it is probably safer to always only do the mapping *iff* the key is present to prevent some crashes in the future if the discord API changes. 

Here is a stack trace:
```
** (Protocol.UndefinedError) protocol Enumerable not implemented for nil of type Atom. This protocol is implemented for the following type(s): Ecto.Adapters.SQL.Stream, Postgrex.Stream, DBConnection.PrepareStream, DBConnection.Stream, KafkaEx.Stream, Timex.Interval, Floki.HTMLTree, HashDict, GenEvent.Stream, File.Stream, Map, IO.Stream, Function, HashSet, Stream, Range, MapSet, List, Date.Range
    (elixir 1.10.4) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir 1.10.4) lib/enum.ex:141: Enumerable.reduce/3
    (elixir 1.10.4) lib/enum.ex:3383: Enum.map/2
    (alchemy 0.6.8) lib/Structs/structs.ex:36: anonymous fn/2 in Alchemy.Structs.field_map/3
    (elixir 1.10.4) lib/map.ex:837: Map.get_and_update/3
    (alchemy 0.6.8) lib/Structs/structs.ex:36: Alchemy.Structs.field_map/3
    (alchemy 0.6.8) lib/Structs/Messages/message.ex:121: Alchemy.Message.from_map/1
    (alchemy 0.6.8) lib/Discord/events.ex:138: Alchemy.Discord.Events.handle/2
    ```