### PR TITLE
fix: missing 'animated' property on emoji struct

### DIFF
--- a/lib/Structs/Guild/emoji.ex
+++ b/lib/Structs/Guild/emoji.ex
@@ -2,9 +2,15 @@ defmodule Alchemy.Guild.Emoji do
   @moduledoc false
 
   @derive Poison.Encoder
-  defstruct [:id, :name, :roles, :require_colons, :managed]
+  defstruct [:id, :name, :roles, :require_colons, :managed, :animated, :available]
 
   defimpl String.Chars, for: __MODULE__ do
-    def to_string(emoji), do: "<:#{emoji.name}:#{emoji.id}>"
+    def to_string(emoji) do
+      if emoji.animated do
+        "<a:#{emoji.name}:#{emoji.id}>"
+      else
+        "<:#{emoji.name}:#{emoji.id}>"
+      end
+    end
   end
 end


### PR DESCRIPTION
Animated emotes did not display properly as they were missing the `a` in their format

```
<a:name:id> # animated emote format
<:name:id> # static emote format
```