### PR TITLE
Fixed spelling mistake and added handler for ForumChannels

### DIFF
--- a/lib/Discord/events.ex
+++ b/lib/Discord/events.ex
@@ -205,6 +205,6 @@ defmodule Alchemy.Discord.Events do
   end
 
   def handle(_, _) do
-    {:unkown, []}
+    {:unknown, []}
   end
 end

--- a/lib/EventStage/cacher.ex
+++ b/lib/EventStage/cacher.ex
@@ -44,8 +44,8 @@ defmodule Alchemy.EventStage.Cacher do
     # We will receive the signals GUILD_MEMBER_UPDATE & GUILD_CREATE simultaneously.
     #
     # If the GUILD_MEMBER_UPDATE signal gets processed before the GUILD_CREATE
-    # the Cache will crash as no genserver with the given guild id exists in the 
-    # Registry yet. 
+    # the Cache will crash as no genserver with the given guild id exists in the
+    # Registry yet.
     if Registry.lookup(:guilds, guild_id) != [] do
       Events.handle(type, payload)
     else
@@ -55,7 +55,7 @@ defmodule Alchemy.EventStage.Cacher do
         }"
       )
 
-      {:unkown, []}
+      {:unknown, []}
     end
   end
 

--- a/lib/Structs/Channels/channel.ex
+++ b/lib/Structs/Channels/channel.ex
@@ -14,7 +14,8 @@ defmodule Alchemy.Channel do
     GroupDMChannel,
     NewsChannel,
     StoreChannel,
-    StageVoiceChannel
+    StageVoiceChannel,
+    ForumChannel
   }
 
   alias Alchemy.User
@@ -164,7 +165,7 @@ defmodule Alchemy.Channel do
 
     Whether or not the channel is considered nsfw
   - `last_message_id`
-    
+
     The id of the last message sent in the channel, if any
   - `parent_id`
 
@@ -227,7 +228,7 @@ defmodule Alchemy.Channel do
 
     The id of the guild this channel belongs to
   - `position`
-    
+
     The sorting position of this channel in the guild
   - `permission_overwrites`
 
@@ -348,8 +349,11 @@ defmodule Alchemy.Channel do
       13 ->
         StageVoiceChannel.from_map(map)
 
+      15 ->
+        ForumChannel.from_map(map)
+
       _ ->
-        Logger.error("Unkown channel type: #{inspect(map)}")
+        Logger.error("[Alchemy] Unknown channel type: #{inspect map["type"]}, inspect: #{inspect(map)}")
         nil
     end
   end

--- a/lib/Structs/Channels/forum_channel.ex
+++ b/lib/Structs/Channels/forum_channel.ex
@@ -1,0 +1,24 @@
+defmodule Alchemy.Channel.ForumChannel do
+  @moduledoc false
+  alias Alchemy.OverWrite
+  import Alchemy.Structs
+
+  defstruct [
+    :id,
+    :guild_id,
+    :position,
+    :permission_overwrites,
+    :name,
+    :topic,
+    :nsfw,
+    :last_message_id,
+    :parent_id,
+    :last_pin_timestamp
+  ]
+
+  def from_map(map) do
+    map
+    |> field_map("permission_overwrites", &map_struct(&1, OverWrite))
+    |> to_struct(__MODULE__)
+  end
+end


### PR DESCRIPTION
Discord recently added forums, threads/channels inside these generate an error. Said error also had a spelling mistake in it.